### PR TITLE
Init function return type changed to "int"

### DIFF
--- a/src/ofxEtherdream.cpp
+++ b/src/ofxEtherdream.cpp
@@ -40,7 +40,7 @@ bool ofxEtherdream::checkConnection(bool bForceReconnect) {
 }
 
 //--------------------------------------------------------------
-void ofxEtherdream::init() {
+int ofxEtherdream::init() {
     int device_num = etherdream_dac_count();
 	if (!device_num || idEtherdreamConnection>device_num) {
 		ofLogWarning() << "ofxEtherdream::init - No DACs found";

--- a/src/ofxEtherdream.h
+++ b/src/ofxEtherdream.h
@@ -57,7 +57,7 @@ public:
     bool getWaitBeforeSend() const;
     
 private:
-    void init();
+    int init();
     
 private:
     enum {


### PR DESCRIPTION
g++ on ubuntu didn't want to compile a "void" function that returns an "int". 
Compiles fine after this change