### PR TITLE
small fixes for openFrameworks 0.11.2 

### DIFF
--- a/src/ofxEtherdream.cpp
+++ b/src/ofxEtherdream.cpp
@@ -82,7 +82,7 @@ void ofxEtherdream::threadedFunction() {
 
 //--------------------------------------------------------------
 void ofxEtherdream::start() {
-    startThread(true, false);  // TODO: blocking or nonblocking?
+    startThread();  // TODO: blocking or nonblocking?
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
Update ofxEtherdream.cpp
> startThread doesn't have params in current oF.