### PR TITLE
fix: Remove unused return values

### DIFF
--- a/src/ofxEtherdream.cpp
+++ b/src/ofxEtherdream.cpp
@@ -44,7 +44,7 @@ void ofxEtherdream::init() {
     int device_num = etherdream_dac_count();
 	if (!device_num || idEtherdreamConnection>device_num) {
 		ofLogWarning() << "ofxEtherdream::init - No DACs found";
-		return 0;
+		return;
 	}
     
 	for (int i=0; i<device_num; i++) {
@@ -54,7 +54,7 @@ void ofxEtherdream::init() {
     device = etherdream_get(idEtherdreamConnection);
     
     ofLogNotice() << "ofxEtherdream::init - Connecting...";
-    if (etherdream_connect(device) < 0) return 1;
+    if (etherdream_connect(device) < 0) return;
 
     ofLogNotice() << "ofxEtherdream::init - done";
     


### PR DESCRIPTION
`return 0` in `void ofxEtherdream::init()` is throwing build errors with latest oF. This PR removes them. Tested with oF `0.12.0`.